### PR TITLE
fix: Changed Node engines to support higher Node version than v14.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "typescript": "4.4.2"
       },
       "engines": {
-        "node": "14.x"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "Sosiaaliturvatunnus"
   ],
   "engines": {
-    "node": "14.x"
+    "node": ">=14.0.0"
   },
   "scripts": {
     "dist": "tsc && node-minify --compressor babel-minify --input dist/finnish-ssn.js --output dist/finnish-ssn.min.js ",


### PR DESCRIPTION
When installing this package in a project that uses for example Node v16 it fails.